### PR TITLE
Parallelize word processing in suggest command

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,7 +12,7 @@ name = "divvunspell"
 path = "src/main.rs"
 
 [features]
-accuracy = ["dep:csv", "dep:rayon", "dep:indicatif", "dep:jiff", "dep:unic-segment"]
+accuracy = ["dep:csv", "dep:indicatif", "dep:jiff", "dep:unic-segment"]
 
 [dependencies]
 divvun-fst = { features = ["compression"], path = ".." }
@@ -24,8 +24,9 @@ box-format.workspace = true
 clap.workspace = true
 anyhow.workspace = true
 
+rayon = "1.10"
+
 csv = { version = "1.3", optional = true }
-rayon = { version = "1.10", optional = true }
 indicatif = { version = "0.17", features = ["rayon"], optional = true }
 jiff = { version = "0.2", optional = true }
 unic-segment = { version = "0.9", optional = true }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,6 +14,7 @@ use divvun_fst::transducer::TransducerLoader;
 use divvun_fst::transducer::hfst::HfstTransducer;
 use divvun_fst::types::Weight;
 use divvun_fst::vfs::Fs;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use serde::Serialize;
 
 use divvun_fst::{
@@ -254,7 +255,7 @@ impl OutputWriter for JsonWriter {
 }
 
 fn run(
-    speller: Arc<dyn Speller + Send>,
+    speller: Arc<dyn Speller + Send + Sync>,
     words: Vec<String>,
     writer: &mut dyn OutputWriter,
     is_analyzing: bool,
@@ -263,32 +264,42 @@ fn run(
     suggest_cfg: &SpellerConfig,
     verbose: bool,
 ) {
-    for word in words {
-        let is_correct = speller.clone().is_correct_with_config(&word, &suggest_cfg);
-        writer.write_correction(&word, is_correct);
-
-        if is_analyzing {
-            // Get suggestions using the regular suggest path (not analyze_suggest_with_config)
-            // to avoid double analysis
-            let suggestions = speller.clone().suggest_with_config(&word, &suggest_cfg);
-
-            // For each suggestion, get its morphological analyses and filter based on +Spell/NoSugg
-            let mut combined: Vec<(Suggestion, Vec<Suggestion>)> = vec![];
-            for sugg in suggestions {
-                let analyses = speller
-                    .clone()
-                    .analyze_input_with_config(&sugg.value, &suggest_cfg);
-
-                // Only include suggestion if not all analyses have +Spell/NoSugg
-                let all_filtered = analyses.iter().all(|a| a.value.contains("+Spell/NoSugg"));
-                if !all_filtered {
-                    combined.push((sugg, analyses));
+    let results: Vec<(
+        String,
+        bool,
+        Option<Vec<(Suggestion, Vec<Suggestion>)>>,
+        Option<Vec<Suggestion>>,
+    )> = words
+        .par_iter()
+        .map(|word| {
+            let is_correct = speller.clone().is_correct_with_config(word, &suggest_cfg);
+            if is_analyzing {
+                let suggestions = speller.clone().suggest_with_config(word, &suggest_cfg);
+                let mut combined: Vec<(Suggestion, Vec<Suggestion>)> = vec![];
+                for sugg in suggestions {
+                    let analyses = speller
+                        .clone()
+                        .analyze_input_with_config(&sugg.value, &suggest_cfg);
+                    let all_filtered = analyses.iter().all(|a| a.value.contains("+Spell/NoSugg"));
+                    if !all_filtered {
+                        combined.push((sugg, analyses));
+                    }
                 }
+                (word.clone(), is_correct, Some(combined), None)
+            } else if is_suggesting && (is_always_suggesting || !is_correct) {
+                let suggestions = speller.clone().suggest_with_config(word, &suggest_cfg);
+                (word.clone(), is_correct, None, Some(suggestions))
+            } else {
+                (word.clone(), is_correct, None, None)
             }
+        })
+        .collect();
 
+    for (word, is_correct, combined, suggestions) in results {
+        writer.write_correction(&word, is_correct);
+        if let Some(combined) = combined {
             writer.write_combined_suggestions_analyses(&word, &combined, verbose);
-        } else if is_suggesting && (is_always_suggesting || !is_correct) {
-            let suggestions = speller.clone().suggest_with_config(&word, &suggest_cfg);
+        } else if let Some(suggestions) = suggestions {
             writer.write_suggestions(&word, &suggestions, verbose);
         }
     }


### PR DESCRIPTION
Use `par_iter()` from Rayon instead of a sequential for-loop when processing words in the `suggest` command, matching the approach already used in the `accuracy` command.

This gives a significant speedup when processing large word lists via stdin, e.g.:
```sh
divvunspell suggest -a tools/spellcheckers/se.zhfst < test.txt > test.ut.txt
```

Changes:
- Made `rayon` a required (non-optional) dependency for the CLI
- Changed the `run()` function to use `par_iter().map().collect()` for parallel processing
- Updated the speller trait bound to `Send + Sync` to allow sharing across threads
- Results are collected and written sequentially to preserve output order