### PR TITLE
Fix #68: Error model alphabet incorrectly affects word acceptance

### DIFF
--- a/src/speller/mod.rs
+++ b/src/speller/mod.rs
@@ -350,9 +350,9 @@ where
             config
         );
         for word in std::iter::once(word.into()).chain(words.into_iter()) {
-            let worker = SpellerWorker::new(
+            let worker = SpellerWorker::new_lexicon_input(
                 self.clone(),
-                self.to_input_vec(&word),
+                self.to_input_vec_lexicon(&word),
                 config,
                 OutputMode::WithoutTags,
             );
@@ -388,9 +388,9 @@ where
             return vec![];
         }
 
-        let worker = SpellerWorker::new(
+        let worker = SpellerWorker::new_lexicon_input(
             self.clone(),
-            self.to_input_vec(word),
+            self.to_input_vec_lexicon(word),
             config,
             OutputMode::WithTags,
         );
@@ -419,9 +419,9 @@ where
             verbose: false,
             ..config.clone()
         };
-        let worker = SpellerWorker::new(
+        let worker = SpellerWorker::new_lexicon_input(
             self.clone(),
-            self.to_input_vec(word),
+            self.to_input_vec_lexicon(word),
             &non_verbose_config,
             OutputMode::WithoutTags,
         );
@@ -541,6 +541,27 @@ where
         let string_to_symbol = alphabet.string_to_symbol();
 
         tracing::trace!("to_input_vec: {}", word);
+        Graphemes::new(word)
+            .map(|ch| {
+                string_to_symbol
+                    .get(ch)
+                    .copied()
+                    .unwrap_or_else(|| alphabet.unknown().unwrap_or(SymbolNumber::ZERO))
+            })
+            .collect()
+    }
+
+    /// Convert input word to symbol vector using lexicon alphabet.
+    ///
+    /// This is used for lexicon-only operations (is_correct, analyze_input, etc.)
+    /// where we need to match against the lexicon's alphabet, not the error model's.
+    /// Using the mutator alphabet would cause words with letters outside the error
+    /// model alphabet to be incorrectly marked as unknown/incorrect.
+    fn to_input_vec_lexicon(&self, word: &str) -> Vec<SymbolNumber> {
+        let alphabet = self.lexicon().alphabet();
+        let string_to_symbol = alphabet.string_to_symbol();
+
+        tracing::trace!("to_input_vec_lexicon: {}", word);
         Graphemes::new(word)
             .map(|ch| {
                 string_to_symbol

--- a/src/speller/worker.rs
+++ b/src/speller/worker.rs
@@ -25,6 +25,8 @@ pub struct SpellerWorker<'c, T: Transducer, U: Transducer> {
     input: Vec<SymbolNumber>,
     config: &'c SpellerConfig,
     output_mode: OutputMode,
+    /// True if input symbols are already in lexicon alphabet (no translation needed)
+    input_is_lexicon_alphabet: bool,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -45,6 +47,23 @@ where
             input,
             config,
             output_mode,
+            input_is_lexicon_alphabet: false,
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn new_lexicon_input(
+        speller: Arc<HfstSpeller<T, U>>,
+        input: Vec<SymbolNumber>,
+        config: &'c SpellerConfig,
+        output_mode: OutputMode,
+    ) -> SpellerWorker<'c, T, U> {
+        SpellerWorker {
+            speller,
+            input,
+            config,
+            output_mode,
+            input_is_lexicon_alphabet: true,
         }
     }
 
@@ -411,14 +430,20 @@ where
     ) {
         let mutator = self.speller.mutator();
         let lexicon = self.speller.lexicon();
-        let alphabet_translator = self.speller.alphabet_translator();
         let input_state = next_node.input_state.0 as usize;
 
         if input_state >= self.input.len() {
             return;
         }
 
-        let input_sym = alphabet_translator[self.input[input_state as usize].0 as usize];
+        // If input is already in lexicon alphabet, use it directly.
+        // Otherwise, translate from mutator alphabet to lexicon alphabet.
+        let input_sym = if self.input_is_lexicon_alphabet {
+            self.input[input_state]
+        } else {
+            let alphabet_translator = self.speller.alphabet_translator();
+            alphabet_translator[self.input[input_state].0 as usize]
+        };
         let next_lexicon_state = next_node.lexicon_state.incr();
         //        tracing::trace!(
         //            "lexicon consuming {}: {}",
@@ -820,12 +845,12 @@ where
             ..self.config.clone()
         };
 
-        let temp_worker = SpellerWorker {
-            speller: self.speller.clone(),
-            input: temp_input,
-            config: &temp_config,
-            output_mode: OutputMode::WithoutTags,
-        };
+        let temp_worker = SpellerWorker::new(
+            self.speller.clone(),
+            temp_input,
+            &temp_config,
+            OutputMode::WithoutTags,
+        );
 
         while let Some(next_node) = nodes.pop() {
             if next_node.input_state.0 as usize == temp_worker.input.len()


### PR DESCRIPTION
## Summary

Fixes #68 

The error model (mutator) alphabet was incorrectly being used to convert input words for **all** operations, including lexicon-only operations like `is_correct()` and `analyze_input()`.

This caused words containing letters outside the error model alphabet to be marked as `INCORRECT` even when they were present in the lexicon/acceptor.

## Problem

When a word like "Njunnásjaevrie" contains letters (e.g., "á", "š") that are:
- ✅ Present in the lexicon/acceptor alphabet
- ❌ **Not** present in the error model alphabet (e.g., a smaller festschrift error model)

The old code would:
1. Convert the word using the **mutator** alphabet in `to_input_vec()`
2. Map unknown letters → `SymbolNumber::ZERO`
3. Use `alphabet_translator` to translate from mutator → lexicon alphabet
4. But since the letter was already converted to ZERO, it would look for ZERO in the lexicon instead of "á"
5. Word not found → marked as `INCORRECT` ❌

## Solution

For lexicon-only operations (`is_correct`, `analyze_input`, `get_lexicon_weight`):
- Use **lexicon alphabet** directly for input conversion (new `to_input_vec_lexicon()`)
- Skip alphabet translation since symbols are already in the correct alphabet
- Add `input_is_lexicon_alphabet` flag to `SpellerWorker` to track this

For suggestion operations (`suggest`, etc.):
- Continue using **mutator alphabet** (unchanged behavior)

## Changes

- ✨ Add `to_input_vec_lexicon()` method to convert using lexicon alphabet
- ✨ Add `SpellerWorker::new_lexicon_input()` constructor
- ✨ Add `input_is_lexicon_alphabet` field to track alphabet source
- 🔧 Update `lexicon_consume()` to skip translation when input is already in lexicon alphabet
- 🔧 Update `is_correct()`, `analyze_input()`, and `get_lexicon_weight()` to use lexicon alphabet

## Testing

Tested with South Sámi spell checkers as described in issue #68:
- ✅ Words with letters outside error model alphabet now correctly accepted
- ✅ "Njunnásjaevrie" → `[CORRECT]` (was `[INCORRECT]`)
- ✅ "Vuottašvárbohki" → `[CORRECT]` (was `[INCORRECT]`)
- ✅ Common words continue to work correctly