### PR TITLE
Add per-input reweight exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ divvunspell accuracy -c config.json typos.tsv language.zhfst
     "end-penalty": 10.0,
     "mid-penalty": 5.0
   },
+  "reweight-exceptions": [
+    "nuvviDspeller",
+    "Divvun speller for Lule Sami"
+  ],
   "node-pool-size": 128,
   "recase": true,
   "completion-marker": null
@@ -210,6 +214,7 @@ divvunspell accuracy -c config.json typos.tsv language.zhfst
   - **`start-penalty`** (default: `10.0`): Penalty for errors at the start of the word
   - **`end-penalty`** (default: `10.0`): Penalty for errors at the end of the word
   - **`mid-penalty`** (default: `5.0`): Penalty for errors in the middle of the word
+- **`reweight-exceptions`** (default: `[]`): List of exact, case-sensitive input words for which suggestion reweighting is skipped
 - **`node-pool-size`** (default: `128`): Size of node pool for parallelization
 - **`recase`** (default: `true`): Whether to try fixing capitalization before other suggestions
 - **`completion-marker`** (default: `null`): Marker used when suggesting incomplete word parts. Set to `null` to disable

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ divvunspell suggest --archive language.zhfst -A "wordd"
 - `-w, --weight <WEIGHT>` - Maximum weight limit for suggestions
 - `-n, --nbest <N>` - Maximum number of suggestions to return
 - `--no-reweighting` - Disable suggestion reweighting (closer to hfst-ospell behavior)
+- `--no-reweighting-for <WORD>` - Skip suggestion reweighting for this input word; may be repeated
 - `--no-recase` - Disable case-aware suggestion handling
 - `--json` - Output results as JSON
 - `-v, --verbose` - Show detailed weight information (lexicon, mutator, reweighting)

--- a/cli/src/accuracy.rs
+++ b/cli/src/accuracy.rs
@@ -76,6 +76,7 @@ static CFG: SpellerConfig = SpellerConfig {
     max_weight: Some(Weight(10000.0)),
     beam: None,
     reweight: Some(ReweightingConfig::default_const()),
+    reweight_exceptions: Vec::new(),
     node_pool_size: 128,
     recase: true,
     completion_marker: None,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -358,6 +358,10 @@ struct SuggestArgs {
     #[arg(long = "no-reweighting")]
     disable_reweight: bool,
 
+    /// Skip reweighting for this input word (can be specified multiple times)
+    #[arg(long = "no-reweighting-for", value_name = "WORD")]
+    no_reweighting_for: Vec<String>,
+
     /// Disables recasing algorithm (makes results more like hfst-ospell)
     #[arg(long = "no-recase")]
     disable_recase: bool,
@@ -471,6 +475,9 @@ fn suggest(args: SuggestArgs) -> anyhow::Result<()> {
     if args.disable_reweight {
         suggest_cfg.reweight = None;
     }
+    suggest_cfg
+        .reweight_exceptions
+        .extend(args.no_reweighting_for);
     if args.disable_recase {
         suggest_cfg.recase = false;
     }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -247,6 +247,7 @@ impl FromForeign<*const std::ffi::c_void, SpellerConfig> for SpellerConfigMarsha
                 None
             },
             reweight,
+            reweight_exceptions: Vec::new(),
             node_pool_size: config.node_pool_size,
             recase: true,
             completion_marker: None,

--- a/src/speller/mod.rs
+++ b/src/speller/mod.rs
@@ -514,6 +514,9 @@ pub struct SpellerConfig {
     /// extra penalties for different edit distance type errors
     #[serde(default = "default_reweight")]
     pub reweight: Option<ReweightingConfig>,
+    /// input words for which reweighting should be skipped
+    #[serde(default)]
+    pub reweight_exceptions: Vec<String>,
     /// some parallel stuff?
     #[serde(default = "default_node_pool_size")]
     pub node_pool_size: usize,
@@ -543,6 +546,7 @@ impl SpellerConfig {
             max_weight: default_max_weight(),
             beam: default_beam(),
             reweight: default_reweight(),
+            reweight_exceptions: Vec::new(),
             node_pool_size: default_node_pool_size(),
             recase: default_recase(),
             completion_marker: None,
@@ -905,12 +909,27 @@ where
             return vec![];
         }
 
-        if let Some(reweight) = config.reweight.as_ref() {
+        let config_without_exception_reweight;
+        let effective_config = if config
+            .reweight_exceptions
+            .iter()
+            .any(|exception| exception == word)
+        {
+            config_without_exception_reweight = SpellerConfig {
+                reweight: None,
+                ..config.clone()
+            };
+            &config_without_exception_reweight
+        } else {
+            config
+        };
+
+        if let Some(reweight) = effective_config.reweight.as_ref() {
             let case_handler = word_variants(word);
 
-            self.suggest_case(case_handler, config, reweight, mode)
+            self.suggest_case(case_handler, effective_config, reweight, mode)
         } else {
-            self.suggest_single(word, config, mode)
+            self.suggest_single(word, effective_config, mode)
         }
     }
 

--- a/tests/speller_integration.rs
+++ b/tests/speller_integration.rs
@@ -666,6 +666,21 @@ fn test_reweight_zero_for_correct() {
     assert_suggests_at_weight(&test_speller(), "cat", "cat", 0.0, &reweight_config());
 }
 
+#[test]
+fn test_reweight_exception_skips_only_matching_input() {
+    let s = test_speller();
+    let mut cfg = reweight_config();
+    cfg.reweight_exceptions = vec!["kat".to_string()];
+
+    let exception_suggs = suggestion_values(&s, "kat", &cfg);
+    let exception_cat = exception_suggs.iter().find(|(v, _)| v == "cat").unwrap().1;
+    assert_eq!(exception_cat, 5.0);
+
+    let regular_suggs = suggestion_values(&s, "cad", &cfg);
+    let regular_cat = regular_suggs.iter().find(|(v, _)| v == "cat").unwrap().1;
+    assert!(regular_cat > 5.0);
+}
+
 // Regression for #65: mixed-case inputs took the CaseMode::FirstResults path
 // (plus the lowercase fallback) which previously skipped reweight entirely,
 // returning an unpenalised weight and zero reweight_* fields. A mixed-case


### PR DESCRIPTION
## Motivation

The reweighting system completely throws off the easter egg triggered with `nuvviDspeller`: each of the three suggestions get very high weights because of the (irrelevant) editing distance between trigger string and "suggestions" with version info. This causes the suggestions to be partially or totally discarded, killing of the easter egg version info feature completely. Adding a reweight exception solves this.

The new feature can also be used for highly targeted full-word corrections in cases with large editing distances compared to other suggestion alternatives generated by the error model for the same model.

## Summary
- add `reweight-exceptions` to `SpellerConfig` for exact input-word matches
- add repeatable `--no-reweighting-for <WORD>` CLI support
- document and test the behavior

## Tests
- `cargo test --workspace`
- `cargo test -p divvunspell-cli --features accuracy`